### PR TITLE
Add Engine event handlers

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -43,6 +43,13 @@ const actorB = new Actor(
 engine.actors.push(actorA);
 engine.actors.push(actorB);
 
+const handlePause = () => console.log("paused");
+const handleResume = () => console.log("resumed");
+
+engine.addHandler("pause", handlePause)
+
+engine.addHandler("resume", handleResume)
+
 engine.start();
 
 setTimeout(() => engine.pause(), 2500);

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -45,5 +45,5 @@ engine.actors.push(actorB);
 
 engine.start();
 
-setTimeout(() => engine.stop(), 2500);
-setTimeout(() => engine.start(), 3500);
+setTimeout(() => engine.pause(), 2500);
+setTimeout(() => engine.resume(), 3500);

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -47,10 +47,27 @@ const handlePause = () => console.log("paused");
 const handleResume = () => console.log("resumed");
 
 engine.addHandler("pause", handlePause)
-
 engine.addHandler("resume", handleResume)
+
+const handleUpdate = (dt) => {
+  console.log(dt);
+}
+
+engine.addHandler("update", handleUpdate);
 
 engine.start();
 
 setTimeout(() => engine.pause(), 2500);
 setTimeout(() => engine.resume(), 3500);
+
+setTimeout(() => engine.pause(), 4500);
+setTimeout(() => engine.resume(), 5500);
+
+setTimeout(() => {
+  engine.removeHandler("pause", handlePause);
+  engine.removeHandler("resume", handleResume);
+  engine.removeHandler("update", handleUpdate);
+}, 6000);
+
+setTimeout(() => engine.pause(), 6500);
+setTimeout(() => engine.resume(), 7500);

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,7 +15,7 @@
       }
 
       #c {
-        width: 1280px;
+        width: 80vw;
         height: 720px;
         background-color: #000;
       }

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -60,7 +60,7 @@ export default class Engine {
    */
   pause = () => {
     this.#isPaused = true;
-    this.#eventHandlers["resume"].forEach(handler => handler());
+    this.#eventHandlers["pause"].forEach(handler => handler());
   }
 
   /**
@@ -93,7 +93,7 @@ export default class Engine {
     // assert handler is a function
     if (typeof handler !== "function") throw new Error("handler must be a function");
     // assert event is a valid event
-    if (!this.#eventTypes.includes(event)) throw new Error("event is not a valid event");
+    if (!this.#validEvents.includes(event)) throw new Error("event is not a valid event");
 
     // add handler function to array of handlers for specified event
     this.#eventHandlers[event].push(handler);
@@ -116,7 +116,7 @@ export default class Engine {
     // assert handler is a function
     if (typeof handler !== "function") throw new Error("handler must be a function");
     // assert event is a valid event
-    if (!this.#eventTypes.includes(event)) throw new Error("event is not a valid event");
+    if (!this.#validEvents.includes(event)) throw new Error("event is not a valid event");
 
     // remove handler function from array of handlers for specified event
     const index = this.#eventHandlers[event].indexOf(handler);
@@ -180,7 +180,7 @@ export default class Engine {
   #hasInit = false;
 
   /**
-   * Array of possible event types to be handled
+   * Enum of possible event types to be handled
    * 
    * @private
    * @type {Array}
@@ -189,7 +189,7 @@ export default class Engine {
    * @property {String} pause - triggered on engine pause
    * @property {String} resume - triggered on engine resume
    */
-  #eventTypes = ["update", "pause", "resume"];
+  #validEvents = ["update", "pause", "resume"];
 
   /**
    * Array of event handlers for each event type

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -61,7 +61,7 @@ export default class Engine {
    * Pauses engine update loop. Game will continue requesting 
    * animation frames, but will not continue to update or draw.
    */
-  stop = () => {
+  pause = () => {
     this.#isPaused = true;
   }
 
@@ -71,6 +71,56 @@ export default class Engine {
    * @return {Boolean} true if engine is paused, false otherwise
    */
   isPaused = () => this.#isPaused;
+
+  /**
+   * Adds a handler function to execute on a specific event.
+   * @param {String} event - name of event to handle
+   * @param {Function} handler - function to execute when event is triggered
+   * 
+   * @throws {Error} if event is not a string
+   * @throws {Error} if handler is not a function
+   * @throws {Error} if event is not a valid event
+   */
+  addHandler = (event, handler) => {
+    // assert event is a string
+    if (typeof event !== "string") throw new Error("event must be a string");
+    // assert handler is a function
+    if (typeof handler !== "function") throw new Error("handler must be a function");
+    // assert event is a valid event
+    if (!this.#eventTypes.includes(event)) throw new Error("event is not a valid event");
+
+    // add handler function to array of handlers for specified event
+    this.#eventHandlers[event].push(handler);
+  }
+
+  /**
+   * Removes handler fucntion from event
+   * 
+   * @param {String} event - name of event to remove handler from
+   * @param {Function} handler - function to remove from event
+   * @return {Boolean} true if handler was removed, false otherwise
+   * 
+   * @throws {Error} if event is not a string
+   * @throws {Error} if handler is not a function
+   * @throws {Error} if event is not a valid event
+   */
+  removeHandler = (event, handler) => {
+    // assert event is a string
+    if (typeof event !== "string") throw new Error("event must be a string");
+    // assert handler is a function
+    if (typeof handler !== "function") throw new Error("handler must be a function");
+    // assert event is a valid event
+    if (!this.#eventTypes.includes(event)) throw new Error("event is not a valid event");
+
+    // remove handler function from array of handlers for specified event
+    const index = this.#eventHandlers[event].indexOf(handler);
+    if (index !== -1) {
+      this.#eventHandlers[event].splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+
 
   // ****************************************************************
   // Private defs
@@ -124,6 +174,35 @@ export default class Engine {
   #hasInit = false;
 
   /**
+   * Array of possible event types to be handled
+   * 
+   * @private
+   * @type {Array}
+   * 
+   * @property {String} update - triggered on each engine update loop
+   * @property {String} pause - triggered on engine pause
+   * @property {String} resume - triggered on engine resume
+   */
+  #eventTypes = ["update", "pause", "resume"];
+
+  /**
+   * Array of event handlers for each event type
+   *
+   * @private
+   * @type {Object}
+   * 
+   * @property {Array} update - array of update event handlers
+   * @property {Array} pause - array of pause event handlers
+   * @property {Array} resume - array of resume event handlers
+   */
+
+  #eventHandlers = {
+    update: [],
+    pause: [],
+    resume: [],
+  };
+
+  /**
    * Initializes canvas and sets up event listeners
    * 
    * @private
@@ -160,6 +239,9 @@ export default class Engine {
 
       // update relevant actors
       this.actors.forEach(actor => actor.update(dt, this.environment));
+
+      // call event handlers for relevant events
+      this.#eventHandlers["update"].forEach(handler => handler(dt, this.environment));
 
       // filter actors array by those that are NOT queued for disposal
       this.actors.filter(actor => !actor.disposalQueued);

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -44,17 +44,14 @@ export default class Engine {
   actors = [];
 
   /**
-   * Starts engine update loop
+   * Starts engine update loop. Used only once at startup.
    */
   start = () => {
     if (!this.#hasInit) {
       this.#fixDPI();
       this.#animationFrameID = requestAnimationFrame(this.#update);
       this.#hasInit = true;
-    } else {
-      this.#isPaused = false;
     }
-
   }
 
   /**
@@ -63,6 +60,15 @@ export default class Engine {
    */
   pause = () => {
     this.#isPaused = true;
+    this.#eventHandlers["resume"].forEach(handler => handler());
+  }
+
+  /**
+   * Resumes engine update loop.
+   */
+  resume = () => {
+    this.#isPaused = false;
+    this.#eventHandlers["resume"].forEach(handler => handler());
   }
 
   /**
@@ -273,7 +279,6 @@ export default class Engine {
         this.ctx.fillText("dt: " + (1000 / this.#debug.FPS), 5, 25);
       }
     }
-
   }
 
   /**


### PR DESCRIPTION
This PR introduces engine event handlers by:
- updating pause and resume methods for more intuitive pausing
- adding `addHandler` and `removeHandler` functions that work for engine updates (`'update'`), pausing (`'pause'`), and resuming (`'resume'`).
- Updating demo accordingly