### PR TITLE
Stabilize `EventHandler`

### DIFF
--- a/src/core/Engine.ts
+++ b/src/core/Engine.ts
@@ -112,7 +112,7 @@ export default class Engine {
   constructor(canvasElement: HTMLCanvasElement, properties: any = {}) {
     this.canvasElement = canvasElement;
 
-    this.ctx = canvasElement.getContext("2d") as CanvasRenderingContext2D;
+    this.ctx = <CanvasRenderingContext2D>canvasElement.getContext("2d");
 
     let envWidth: number = Number(getComputedStyle(canvasElement).getPropertyValue("width").slice(0, -2));
     let envHeight: number = Number(getComputedStyle(canvasElement).getPropertyValue("height").slice(0, -2));

--- a/src/util/event_handler.ts
+++ b/src/util/event_handler.ts
@@ -53,9 +53,9 @@ export const EventHandler = (() => {
 
           // JSON.stringify is a dirty way to compare two objects because it
           // doesn't account for the possibility of object keys being in
-          // different orders. TODO: use a more robust method to compare two
-          // objects.
+          // different orders.
 
+          // TODO: use a more robust method to compare two objects.
           return JSON.stringify(e.payload) === JSON.stringify(queuedEvent.payload);
         }) === -1;
       });
@@ -64,6 +64,8 @@ export const EventHandler = (() => {
       queue = queue.filter(queuedEvent => queuedEvent.isPersistent);
     };
 
+    // FIXME: don't dispatch onmousedown if mouse is already down; wait for
+    // onmouseup before dispatching again
     const queueMouseDownEvents = (e: any): void => {
       addToQueue("onmousedown", { x: e.x, y: e.y });
       addToQueue("whilemousedown", { x: e.x, y: e.y }, true, "onmouseup");

--- a/src/util/index.d.ts
+++ b/src/util/index.d.ts
@@ -1,6 +1,5 @@
-// TODO: add mouse button to event payload
 type ValidEventPayload =
-  | { x: number, y: number }          // mouse events
+  | { button: number, x: number, y: number }          // mouse events
   | { key: string }     // key events
   | { width: number, height: number } // resize event
   | { deltaTime: number }             // tick event
@@ -19,7 +18,7 @@ type ValidEventPayload =
 type EventHandler = {
   addListener: (type: ValidEventType, callback: ((ev: ValidEventPayload) => void)) => void,
   removeListener: (type: ValidEventType, callback: ((ev: ValidEventPayload) => void)) => void,
-  queueEvent: (type: ValidEventType, payload: ValidEventPayload, isPersistent?: boolean, persistUntil?: string, isStrict?: boolean) => void,
+  queueEvent: (type: ValidEventType, payload: ValidEventPayload, isPersistent?: boolean, comparisonType?: string) => void,
   dequeueEvent: (type: ValidEventType) => void,
   dispatchQueue: () => void,
   getQueuedEvents: () => Array<QueuedEvent>,
@@ -38,18 +37,14 @@ type EventHandler = {
  * @property {boolean} isPersistent Whether or not the event should persist
  * until the event name described in persistUntil is called, or until the event
  * is explicitly removed from the queue.
- * @property {string} persistUntil The name of the event to persist until.
- * If isPersistent is true and persistUntil is an empty string, the event will
- * persist until explicitly removed from the queue.
- * @property {boolean} isStrict Whether or not the event should be checked
- * against the persistUntil event's payload when filtering.
+ * @property {string} comparisonType The name of the event to compare against
+ * checking if the event should still persist.
  */
 type QueuedEvent = {
   type: ValidEventType,
   payload: ValidEventPayload,
   isPersistent: boolean,
-  persistUntil: string,
-  isStrict: boolean,
+  comparisonType: string
 }
 
 /**

--- a/src/util/index.d.ts
+++ b/src/util/index.d.ts
@@ -1,9 +1,15 @@
+type MouseEventPayload = { button: number, x: number, y: number };
+type KeyEventPayload = { key: string };
+type ResizeEventPayload = { width: number, height: number };
+type TickEventPayload = { deltaTime: number };
+type RenderEventPayload = { interpolationFactor: number };
+
 type ValidEventPayload =
-  | { button: number, x: number, y: number }          // mouse events
-  | { key: string }     // key events
-  | { width: number, height: number } // resize event
-  | { deltaTime: number }             // tick event
-  | { interpolationFactor: number }   // render event
+  | MouseEventPayload
+  | KeyEventPayload
+  | ResizeEventPayload
+  | TickEventPayload
+  | RenderEventPayload
 
 /**
  * @typedef EventHandler A singleton that handles event subscription,

--- a/src/util/index.d.ts
+++ b/src/util/index.d.ts
@@ -1,3 +1,4 @@
+// TODO: add mouse button to event payload
 type ValidEventPayload =
   | { x: number, y: number }          // mouse events
   | { key: string }     // key events

--- a/src/util/texture_cache.ts
+++ b/src/util/texture_cache.ts
@@ -60,7 +60,7 @@ export const TextureCache = (() => {
        * @returns {Texture} the texture loaded from the path or cache
        */
       load: async (path: string): Promise<ImageBitmap> => {
-        const cachedTexture: ImageBitmap | undefined = searchCache(path) as ImageBitmap;
+        const cachedTexture: ImageBitmap | undefined = searchCache(path);
 
         return new Promise((resolve, reject) => {
           cachedTexture ? resolve(cachedTexture) : resolveBitmapFromPath(path, resolve, reject);


### PR DESCRIPTION
This PR fixes some issues present in the event handler:
- fixes `whilekeydown` event double-firing (once from persistence, once from `onkeydown` event repeat)
- adds mouse button type into payload
- enforces strict comparison for all persistent events
- renames some event properties to be more descriptive