### PR TITLE
Add preload screen before tick cycle

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -29,7 +29,7 @@ actorA.preload = () => new Promise(async (resolve, reject) => {
   actorA.textureID = "texmap";
   actorB.textureID = "texmap";
 
-  resolve();
+  setTimeout(resolve(), 1500);
 });
 
 actorA.addListener("onkeydown", (e) => {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -20,17 +20,18 @@ const scene = new Scene("SceneA", engine, camera, { position: vec(10, 10), size:
 const actorA = new Actor("actorA", scene, { position: vec(150, 150), size: vec(64, 64), isDebugEnabled: true });
 const actorB = new Actor("actorB", scene, { position: vec(-200, 450), size: vec(64, 64), velocity: vec(0.1, 0), isDebugEnabled: true });
 
-actorA.preload = () => new Promise(async (resolve, reject) => {
+actorA.preload = async () => {
   const bitmap = await TextureCache.getInstance().load(characterSpritemap);
+
+  // long loading time example
+  await new Promise(resolve => setTimeout(resolve, 1000));
 
   actorA.addTexture("texmap", bitmap, vec(32, 32), 200);
   actorB.addTexture("texmap", bitmap, vec(32, 32), 200);
 
   actorA.textureID = "texmap";
   actorB.textureID = "texmap";
-
-  setTimeout(resolve(), 1500);
-});
+};
 
 actorA.addListener("onkeydown", (e) => {
   if (e.key === "r") {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -17,20 +17,19 @@ const camera = new Camera("camera", engine);
 
 const scene = new Scene("SceneA", engine, camera, { position: vec(10, 10), size: vec(500, 500) }, { background: "#110022" });
 
-const actorA = new Actor("actorA", scene, { position: vec(150, 150), size: vec(64, 64) });
-const actorB = new Actor("actorB", scene, { position: vec(-200, 450), size: vec(64, 64), velocity: vec(0.1, 0) });
-
-actorA.isDebugEnabled = true;
-actorB.isDebugEnabled = true;
+const actorA = new Actor("actorA", scene, { position: vec(150, 150), size: vec(64, 64), isDebugEnabled: true });
+const actorB = new Actor("actorB", scene, { position: vec(-200, 450), size: vec(64, 64), velocity: vec(0.1, 0), isDebugEnabled: true });
 
 actorA.preload = () => new Promise(async (resolve, reject) => {
   const bitmap = await TextureCache.getInstance().load(characterSpritemap);
+
   actorA.addTexture("texmap", bitmap, vec(32, 32), 200);
   actorB.addTexture("texmap", bitmap, vec(32, 32), 200);
+
   actorA.textureID = "texmap";
   actorB.textureID = "texmap";
 
-  setTimeout(() => resolve(), 3000);
+  resolve();
 });
 
 actorA.addListener("onkeydown", (e) => {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -23,17 +23,15 @@ const actorB = new Actor("actorB", scene, { position: vec(-200, 450), size: vec(
 actorA.isDebugEnabled = true;
 actorB.isDebugEnabled = true;
 
-actorA.preload = async () => {
-  const bitmap = await TextureCache.getInstance().load(animationSpritemap);
-
-  console.log("Loaded bitmap: ", bitmap);
-
-  actorA.addTexture("texmap", bitmap, vec(64, 64), 200);
-  actorB.addTexture("texmap", bitmap, vec(64, 64), 200);
-
+actorA.preload = () => new Promise(async (resolve, reject) => {
+  const bitmap = await TextureCache.getInstance().load(characterSpritemap);
+  actorA.addTexture("texmap", bitmap, vec(32, 32), 200);
+  actorB.addTexture("texmap", bitmap, vec(32, 32), 200);
   actorA.textureID = "texmap";
   actorB.textureID = "texmap";
-};
+
+  setTimeout(() => resolve(), 3000);
+});
 
 actorA.addListener("onkeydown", (e) => {
   if (e.key === "r") {

--- a/src/core/Engine.ts
+++ b/src/core/Engine.ts
@@ -159,7 +159,6 @@ export default class Engine {
 
     // wait for each scene to load up assets and connect textures / animations
     await Promise.all(Array.from(this.scenes.values()).map((scene) => scene.start()));
-    // await Promise.all(Array.from(this.scenes.values()).map((scene) => scene.preload()));
 
     // initialize events
     this.eventHandler.attachEventListeners(this.canvasElement);

--- a/src/elements/actor.ts
+++ b/src/elements/actor.ts
@@ -85,10 +85,6 @@ export default class Actor extends Element {
   // ⚓ PUBLIC METHODS
   // ****************************************************************
 
-  override start = (): Promise<any> => {
-    return this.preload().then(() => this.engine.preloadedActorCount++);
-  }
-
   override internalTick = (timestep: number): void => {
     if (this.isGravityEnabled) {
       this.velocity = add(this.velocity, div(this.scene.environment.gravity, timestep));

--- a/src/elements/actor.ts
+++ b/src/elements/actor.ts
@@ -85,6 +85,10 @@ export default class Actor extends Element {
   // ⚓ PUBLIC METHODS
   // ****************************************************************
 
+  override start = (): Promise<any> => {
+    return this.preload().then(() => this.engine.preloadedActorCount++);
+  }
+
   override internalTick = (timestep: number): void => {
     if (this.isGravityEnabled) {
       this.velocity = add(this.velocity, div(this.scene.environment.gravity, timestep));

--- a/src/elements/element.ts
+++ b/src/elements/element.ts
@@ -1,4 +1,3 @@
-import { createTextChangeRange } from "typescript";
 import Engine from "../core/engine";
 import { add, mult, sub, vec } from "../math/vector";
 
@@ -94,10 +93,15 @@ export default class Element {
   }
 
   start = (): Promise<any> => {
-    return this.preload().then(() => {
-      this.isPreloaded = true;
-      this.engine.preloadedActorCount++
-    }).catch((err) => console.error(err));
+    return new Promise((resolve, reject) => {
+      this.preload()
+        .then(() => {
+          this.isPreloaded = true;
+          this.engine.preloadedActorCount++;
+          resolve(true);
+        })
+        .catch((err) => reject(err));
+    });
   };
 
   /**
@@ -106,7 +110,7 @@ export default class Element {
    *
    * @returns {Promise<any>}
    */
-  preload: () => Promise<any> = async () => Promise.resolve();
+  preload: () => Promise<any> = async () => { };
 
   /**
    * Performs common tick logic for all elements

--- a/src/elements/element.ts
+++ b/src/elements/element.ts
@@ -35,6 +35,8 @@ export default class Element {
    */
   isDebugEnabled: boolean = false;
 
+  protected isPreloaded: boolean = false;
+
   // ****************************************************************
   // ⚓ PRIVATE DECLARATIONS
   // ****************************************************************

--- a/src/elements/element.ts
+++ b/src/elements/element.ts
@@ -93,7 +93,12 @@ export default class Element {
     this.engine.eventHandler.removeListener(name, callback);
   }
 
-  start = (): void => { };
+  start = (): Promise<any> => {
+    return this.preload().then(() => {
+      this.isPreloaded = true;
+      this.engine.preloadedActorCount++
+    }).catch((err) => console.error(err));
+  };
 
   /**
    * Called once before the first frame cycle. Accepts a generic promise to

--- a/src/elements/element.ts
+++ b/src/elements/element.ts
@@ -93,6 +93,8 @@ export default class Element {
     this.engine.eventHandler.removeListener(name, callback);
   }
 
+  start = (): void => { };
+
   /**
    * Called once before the first frame cycle. Accepts a generic promise to
    * allow for asynchronous loading of textures.

--- a/src/elements/scene.ts
+++ b/src/elements/scene.ts
@@ -51,10 +51,14 @@ export default class Scene extends Element {
   // ****************************************************************
 
   override start = (): Promise<any> => {
-    return this.preload().then(() => {
-      this.isPreloaded = true;
-      return Promise.all(Array.from(this.actors.values()).map(actor => actor.start()));
-    }).catch(err => console.error(err));
+    return new Promise(async (resolve, reject) => {
+      this.preload()
+        .then(() => {
+          this.isPreloaded = true;
+          resolve(Promise.all(Array.from(this.actors.values()).map(actor => actor.start())));
+        })
+        .catch(err => reject(err));
+    });
   };
 
   override internalTick = (targetFrameTimestep: number) => {

--- a/src/elements/scene.ts
+++ b/src/elements/scene.ts
@@ -50,8 +50,11 @@ export default class Scene extends Element {
   // ⚓ PUBLIC METHODS
   // ****************************************************************
 
-  override start = () => {
-    return Promise.all(Array.from(this.actors.values()).map(actor => actor.start()));
+  override start = (): Promise<any> => {
+    return this.preload().then(() => {
+      this.isPreloaded = true;
+      return Promise.all(Array.from(this.actors.values()).map(actor => actor.start()));
+    }).catch(err => console.error(err));
   };
 
   override internalTick = (targetFrameTimestep: number) => {

--- a/src/elements/scene.ts
+++ b/src/elements/scene.ts
@@ -50,10 +50,9 @@ export default class Scene extends Element {
   // ⚓ PUBLIC METHODS
   // ****************************************************************
 
-  override preload = () => {
-    return Promise.all(Array.from(this.actors.values()).map(actor => actor.preload()));
+  override start = () => {
+    return Promise.all(Array.from(this.actors.values()).map(actor => actor.start()));
   };
-
 
   override internalTick = (targetFrameTimestep: number) => {
     Array.from(this.actors.values()).forEach(actor => actor.tick(targetFrameTimestep));


### PR DESCRIPTION
This PR adds a dynamic preloading screen that shows preload progress before tick cycle.

All elements now have an overridable preload function, and use an async function instead of a Promise with an async callback. The syntax is a lot easier to digest:
```ts 
// previously
actor.preload = new Promise(async (resolve, reject) => {
    const texture = await TextureCache.getInstance().load(sprite);

    // do stuff

    resolve();
});

// now ✨
actor.preload = async () => {
    const texture = await TextureCache.getInstance().load(sprite);

    // do stuff
};
```