### PR TITLE
Add camera into render cycle

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -15,7 +15,7 @@ const engine = new Engine(canvas, { isDebugEnabled: true });
 
 const camera = new Camera("camera", engine, { position: vec(50, 50) });
 
-const scene = new Scene("SceneA", engine, camera, { position: vec(10, 10), size: vec(500, 500), background: "#110022" });
+const scene = new Scene("SceneA", engine, camera, { position: vec(10, 10), size: vec(1000, 1000), background: "#110022" });
 
 const actorA = new Actor("actorA", scene, { position: vec(150, 150), size: vec(64, 64), isDebugEnabled: true });
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -11,9 +11,9 @@ import animationSpritemap from "./animationSpritemap.png";
 import characterSpritemap from "./characterSpritemap.png";
 
 const canvas = document.getElementById("c");
-const engine = new Engine(canvas, { isDebugEnabled: true });
+const engine = new Engine(canvas, { isDebugEnabled: false });
 
-const camera = new Camera("camera", engine, { position: vec(50, 50) });
+const camera = new Camera("camera", engine, { position: vec(50, 50), zoom: 1.5 });
 
 const scene = new Scene("SceneA", engine, camera, { position: vec(10, 10), size: vec(1000, 1000), background: "#110022" });
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -11,26 +11,18 @@ import animationSpritemap from "./animationSpritemap.png";
 import characterSpritemap from "./characterSpritemap.png";
 
 const canvas = document.getElementById("c");
-const engine = new Engine(canvas);
+const engine = new Engine(canvas, { isDebugEnabled: true });
 
-const camera = new Camera("camera", engine);
+const camera = new Camera("camera", engine, { position: vec(50, 50) });
 
-const scene = new Scene("SceneA", engine, camera, { position: vec(10, 10), size: vec(500, 500) }, { background: "#110022" });
+const scene = new Scene("SceneA", engine, camera, { position: vec(10, 10), size: vec(500, 500), background: "#110022" });
 
 const actorA = new Actor("actorA", scene, { position: vec(150, 150), size: vec(64, 64), isDebugEnabled: true });
-const actorB = new Actor("actorB", scene, { position: vec(-200, 450), size: vec(64, 64), velocity: vec(0.1, 0), isDebugEnabled: true });
 
 actorA.preload = async () => {
   const bitmap = await TextureCache.getInstance().load(characterSpritemap);
-
-  // long loading time example
-  //await new Promise(resolve => setTimeout(resolve, 1000));
-
   actorA.addTexture("texmap", bitmap, vec(32, 32), 200);
-  actorB.addTexture("texmap", bitmap, vec(32, 32), 200);
-
   actorA.textureID = "texmap";
-  actorB.textureID = "texmap";
 };
 
 actorA.addListener("onkeydown", (e) => {
@@ -57,18 +49,18 @@ actorA.addListener("ontick", (e) => {
   actorA.position.y += actorA.velocity.y * e.deltaTime;
 });
 
-actorB.addListener("ontick", (e) => {
-  actorB.position.x += actorB.velocity.x * e.deltaTime;
-
-  if (actorB.position.x > scene.size.x) {
-    actorB.position.x = -250;
-  }
+camera.addListener("whilekeydown", (e) => {
+  if (e.key === "d") camera.velocity.x = 0.4
+  if (e.key === "a") camera.velocity.x = -0.4
+  if (e.key === "w") camera.velocity.y = -0.4
+  if (e.key === "s") camera.velocity.y = 0.4
 });
 
-scene.addListener("ontick", (e) => {
-  scene.position.x += 0.1 * e.deltaTime;
+camera.addListener("ontick", (e) => {
+  camera.velocity = mult(camera.velocity, 0.96);
 
-  if (scene.position.x > 500) scene.position.x = 10;
+  camera.position.x += camera.velocity.x * e.deltaTime;
+  camera.position.y += camera.velocity.y * e.deltaTime;
 });
 
 engine.start();

--- a/src/core/Camera.ts
+++ b/src/core/Camera.ts
@@ -20,22 +20,33 @@ export default class Camera {
 
   position: Vector = vec();
 
+  velocity: Vector = vec();
+
   rotation: Vector = vec();
 
   zoom: number = 1;
 
-  // ****************************************************************
-  // ⚓ CONSTRUCTOR
-  // ****************************************************************
-  constructor(name: string, engine: Engine, options: CameraOptions = {}) {
+  /**
+   * Creates a new camera instance.
+   * @param name unique name of camera
+   * @param engine engine to assign to camera
+   * @param defaultProperties optional properties to assign at creation
+   */
+  constructor(name: string, engine: Engine, defaultProperties: Partial<DefaultCameraProperties> = {}) {
     this.name = name;
     this.internalID = Math.random().toString(36).substring(2, 9) + Date.now().toString(36);
 
     this.engine = engine;
 
-    this.position = options.position ?? this.position;
-    this.rotation = options.rotation ?? this.rotation;
-    this.zoom = options.zoom ?? this.zoom;
+    defaultProperties.position && (this.position = defaultProperties.position);
+    defaultProperties.rotation && (this.rotation = defaultProperties.rotation);
+    defaultProperties.zoom && (this.zoom = defaultProperties.zoom);
+
+    this.engine.debugger.baseSection.addSection(this.name, false)
+      .addItem("Position", () => this.position)
+      .addItem("Velocity", () => this.velocity)
+      .addItem("Zoom", () => this.zoom);
+
   }
 
   // ****************************************************************

--- a/src/core/Engine.ts
+++ b/src/core/Engine.ts
@@ -102,43 +102,33 @@ export default class Engine {
    */
   private isDebugEnabled: boolean = true;
 
-
-  // ****************************************************************
-  // ⚓ CONSTRUCTOR
-  // ****************************************************************
-
   /**
    * Creates a new instance of an Engine.
    *
    * @param canvasElement canvas on which to draw to
-   * @param properties optional property arguments for engine
+   * @param defaultProperties optional properties to assign at creation
    */
-  constructor(canvasElement: HTMLCanvasElement, properties: any = {}) {
+  constructor(canvasElement: HTMLCanvasElement, defaultProperties: Partial<DefaultEngineProperties> = {}) {
     this.canvasElement = canvasElement;
 
     this.ctx = <CanvasRenderingContext2D>canvasElement.getContext("2d");
 
-    let envWidth: number = Number(getComputedStyle(canvasElement).getPropertyValue("width").slice(0, -2));
-    let envHeight: number = Number(getComputedStyle(canvasElement).getPropertyValue("height").slice(0, -2));
-
+    const envWidth: number = Number(getComputedStyle(canvasElement).getPropertyValue("width").slice(0, -2));
+    const envHeight: number = Number(getComputedStyle(canvasElement).getPropertyValue("height").slice(0, -2));
     this._canvasSize = vec(envWidth, envHeight);
 
     this.eventHandler = EventHandler.getInstance();
 
     this.fixDPI();
 
-    this.debugger = new Debugger(this.ctx);
+    this.isDebugEnabled = defaultProperties.isDebugEnabled || false;
 
+    this.debugger = new Debugger(this.ctx);
     this.debugger.baseSection
       .addItem("FPS", () => this._FPS)
       .addItem("runtime", () => ((performance.now() - this._engineStartTime) / 1000))
       .addItem("tick lag", () => this.lag);
   }
-
-
-  // ****************************************************************
-  // ⚓ PUBLIC METHODS
-  // ****************************************************************
 
   getScenesByName = (sceneName: string): Array<Scene> => Array.from(this.scenes.values()).filter((scene) => scene.name === sceneName);
 

--- a/src/core/Engine.ts
+++ b/src/core/Engine.ts
@@ -104,43 +104,33 @@ export default class Engine {
    */
   private isDebugEnabled: boolean = true;
 
-
-  // ****************************************************************
-  // ⚓ CONSTRUCTOR
-  // ****************************************************************
-
   /**
    * Creates a new instance of an Engine.
    *
    * @param canvasElement canvas on which to draw to
-   * @param properties optional property arguments for engine
+   * @param defaultProperties optional properties to assign at creation
    */
-  constructor(canvasElement: HTMLCanvasElement, properties: any = {}) {
+  constructor(canvasElement: HTMLCanvasElement, defaultProperties: Partial<DefaultEngineProperties> = {}) {
     this.canvasElement = canvasElement;
 
     this.ctx = <CanvasRenderingContext2D>canvasElement.getContext("2d");
 
-    let envWidth: number = Number(getComputedStyle(canvasElement).getPropertyValue("width").slice(0, -2));
-    let envHeight: number = Number(getComputedStyle(canvasElement).getPropertyValue("height").slice(0, -2));
-
+    const envWidth: number = Number(getComputedStyle(canvasElement).getPropertyValue("width").slice(0, -2));
+    const envHeight: number = Number(getComputedStyle(canvasElement).getPropertyValue("height").slice(0, -2));
     this._canvasSize = vec(envWidth, envHeight);
 
     this.eventHandler = EventHandler.getInstance();
 
     this.fixDPI();
 
-    this.debugger = new Debugger(this.ctx);
+    this.isDebugEnabled = defaultProperties.isDebugEnabled || false;
 
+    this.debugger = new Debugger(this.ctx);
     this.debugger.baseSection
       .addItem("FPS", () => this._FPS)
       .addItem("runtime", () => ((performance.now() - this._engineStartTime) / 1000))
       .addItem("tick lag", () => this.lag);
   }
-
-
-  // ****************************************************************
-  // ⚓ PUBLIC METHODS
-  // ****************************************************************
 
   getScenesByName = (sceneName: string): Array<Scene> => Array.from(this.scenes.values()).filter((scene) => scene.name === sceneName);
 

--- a/src/core/debugger.ts
+++ b/src/core/debugger.ts
@@ -40,13 +40,13 @@ export class Section {
     ctx.fillRect(position.x, position.y, this.isCollapsed ? 150 : backgroundWidth, 24);
     position.y += 24;
 
-    ctx.font = "16px monospace";
+    ctx.font = "1rem monospace";
     ctx.fillStyle = "white";
     ctx.fillText(this.title + (this.isCollapsed ? " +" : " -"), position.x + 4, position.y - 8);
 
     if (this.isCollapsed) return position;
 
-    ctx.font = "11px monospace";
+    ctx.font = "1rem monospace";
     items.forEach(item => ctx.fillText(item, position.x + 8, position.y += 16));
 
     if (this.items.length) position.y += 8;

--- a/src/core/index.d.ts
+++ b/src/core/index.d.ts
@@ -16,8 +16,12 @@ type DebuggerItem = {
   callback: () => Object;
 }
 
-type CameraOptions = {
+type DefaultCameraProperties = {
   position?: Vector;
   rotation?: Vector;
   zoom?: number;
+}
+
+type DefaultEngineProperties = {
+  isDebugEnabled?: boolean;
 }

--- a/src/elements/actor.ts
+++ b/src/elements/actor.ts
@@ -66,16 +66,12 @@ export default class Actor extends Element {
    * @param scene scene reference to add actor to
    * @param properties Element properties to apply to actor
    */
-  constructor(name: string, scene: Scene, properties?: ElementProperties) {
+  constructor(name: string, scene: Scene, properties: Partial<ElementProperties>) {
     super(name, scene.engine, properties);
 
     this.scene = scene;
 
     this.scene.actors.set(this.ID, this);
-
-    this.position = properties?.position || vec(0, 0);
-    this.velocity = properties?.velocity || vec(0, 0);
-    this.size = properties?.size || vec(0, 0);
 
     this.previousState = this.createLastState();
     this.isDebugEnabled = properties?.isDebugEnabled || false;

--- a/src/elements/element.ts
+++ b/src/elements/element.ts
@@ -65,17 +65,17 @@ export default class Element {
    * @param scene engine reference
    * @param properties Element properties to apply
    */
-  constructor(name: string, engine: Engine, properties: ElementProperties = {}) {
+  constructor(name: string, engine: Engine, properties?: Partial<ElementProperties>) {
     this.name = name;
     this.internalID = Math.random().toString(36).substring(2, 9) + Date.now().toString(36);
 
     this.engine = engine;
 
-    this.position = properties.position ?? this.position;
-    this.velocity = properties.velocity ?? this.velocity;
-    this.rotation = properties.rotation ?? this.rotation;
-    this.size = properties.size ?? this.size;
-    this.isDebugEnabled = properties.isDebugEnabled ?? this.isDebugEnabled;
+    properties?.position && (this.position = properties.position);
+    properties?.velocity && (this.velocity = properties.velocity);
+    properties?.rotation && (this.rotation = properties.rotation);
+    properties?.size && (this.size = properties.size);
+    properties?.isDebugEnabled && (this.isDebugEnabled = properties.isDebugEnabled);
 
     this.previousState = this.createLastState();
 

--- a/src/elements/element.ts
+++ b/src/elements/element.ts
@@ -63,23 +63,21 @@ export default class Element {
    *
    * @param name name of element.
    * @param scene engine reference
-   * @param properties Element properties to apply
+   * @param defaultProperties Element properties to apply on startup
    */
-  constructor(name: string, engine: Engine, properties?: Partial<ElementProperties>) {
+  constructor(name: string, engine: Engine, defaultProperties: Partial<ElementDefaultProperties>) {
     this.name = name;
     this.internalID = Math.random().toString(36).substring(2, 9) + Date.now().toString(36);
 
     this.engine = engine;
 
-    properties?.position && (this.position = properties.position);
-    properties?.velocity && (this.velocity = properties.velocity);
-    properties?.rotation && (this.rotation = properties.rotation);
-    properties?.size && (this.size = properties.size);
-    properties?.isDebugEnabled && (this.isDebugEnabled = properties.isDebugEnabled);
+    defaultProperties.position && (this.position = defaultProperties.position);
+    defaultProperties.velocity && (this.velocity = defaultProperties.velocity);
+    defaultProperties.rotation && (this.rotation = defaultProperties.rotation);
+    defaultProperties.size && (this.size = defaultProperties.size);
+    defaultProperties.isDebugEnabled && (this.isDebugEnabled = defaultProperties.isDebugEnabled);
 
     this.previousState = this.createLastState();
-
-
   }
 
   // ****************************************************************

--- a/src/elements/index.d.ts
+++ b/src/elements/index.d.ts
@@ -6,7 +6,7 @@ interface Texture {
   frameCount: Vector;
 }
 
-type ElementProperties = {
+type ElementDefaultProperties = {
   position: Vector;
   velocity: Vector;
   rotation: Vector;

--- a/src/elements/index.d.ts
+++ b/src/elements/index.d.ts
@@ -7,11 +7,11 @@ interface Texture {
 }
 
 type ElementProperties = {
-  position?: Vector;
-  velocity?: Vector;
-  rotation?: Vector;
-  size?: Vector;
-  isDebugEnabled?: boolean;
+  position: Vector;
+  velocity: Vector;
+  rotation: Vector;
+  size: Vector;
+  isDebugEnabled: boolean;
 }
 
 type ElementState = {

--- a/src/elements/scene.ts
+++ b/src/elements/scene.ts
@@ -76,6 +76,8 @@ export default class Scene extends Element {
     ctx.rect(this.position.x, this.position.y, this.size.x, this.size.y);
     ctx.clip();
 
+    ctx.scale(this.camera.zoom, this.camera.zoom);
+
     Array.from(this.actors.values()).forEach(actor => actor.render(interpolationFactor));
 
     ctx.restore();

--- a/src/elements/scene.ts
+++ b/src/elements/scene.ts
@@ -35,7 +35,7 @@ export default class Scene extends Element {
    * @param properties scene properties
    * @param environment scene environment
    */
-  constructor(name: string, engine: Engine, camera: Camera, properties?: ElementProperties, environment?: SceneEnvironment) {
+  constructor(name: string, engine: Engine, camera: Camera, properties?: ElementProperties, environment?: Partial<SceneEnvironment>) {
     super(name, engine, properties);
 
     this.camera = camera;

--- a/src/elements/scene.ts
+++ b/src/elements/scene.ts
@@ -22,26 +22,21 @@ export default class Scene extends Element {
     gravity: vec(0, 0)
   };
 
-  // ****************************************************************
-  // ⚓ CONSTRUCTOR
-  // ****************************************************************
-
   /**
    * Creates a new Scene instance.
    *
    * @param name name of scene
    * @param engine engine reference to attach scene to
    * @param camera camera to attach to scene
-   * @param properties scene properties
-   * @param environment scene environment
+   * @param defaultProperties optional properties to assign at creation
    */
-  constructor(name: string, engine: Engine, camera: Camera, properties?: ElementProperties, environment?: Partial<SceneEnvironment>) {
-    super(name, engine, properties);
+  constructor(name: string, engine: Engine, camera: Camera, defaultProperties: Partial<ElementDefaultProperties> & Partial<SceneEnvironment> = {}) {
+    super(name, engine, defaultProperties);
 
     this.camera = camera;
 
-    this.environment.background = environment?.background ?? this.environment.background;
-    this.environment.gravity = environment?.gravity ?? this.environment.gravity;
+    this.environment.background = defaultProperties?.background ?? this.environment.background;
+    this.environment.gravity = defaultProperties?.gravity ?? this.environment.gravity;
 
     this.engine.scenes.set(this.ID, this);
 


### PR DESCRIPTION
This PR adds basic camera rendering in the render pipeline. Cameras can be attached to scenes and manipulated, which will subsequently show up in the final render draw.